### PR TITLE
GH-5: Updates to the description view

### DIFF
--- a/app/src/main/java/com/github/jmitchell38488/todo/app/ui/view/RobotoLightEditText.java
+++ b/app/src/main/java/com/github/jmitchell38488/todo/app/ui/view/RobotoLightEditText.java
@@ -3,14 +3,36 @@ package com.github.jmitchell38488.todo.app.ui.view;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.util.AttributeSet;
+import android.view.KeyEvent;
 import android.widget.EditText;
 import android.widget.TextView;
 
 public class RobotoLightEditText extends EditText {
 
+    private EditTextImeBackListener mOnImeBack;
+
     public RobotoLightEditText(Context context, AttributeSet attrs) {
         super(context, attrs);
         this.setTypeface(Typeface.createFromAsset(context.getAssets(), "fonts/roboto/Roboto-Light.ttf"));
+    }
+
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (event.getKeyCode() == KeyEvent.KEYCODE_BACK && event.getAction() == KeyEvent.ACTION_UP) {
+            if (mOnImeBack != null) {
+                mOnImeBack.onImeBack(this, this.getText().toString());
+            }
+        }
+
+        return super.dispatchKeyEvent(event);
+    }
+
+    public void setOnEditTextImeBackListener(EditTextImeBackListener listener) {
+        mOnImeBack = listener;
+    }
+
+    public interface EditTextImeBackListener {
+        public abstract void onImeBack(RobotoLightEditText ctrl, String text);
     }
 
 }

--- a/app/src/main/java/com/github/jmitchell38488/todo/app/ui/view/holder/TodoItemEditHolder.java
+++ b/app/src/main/java/com/github/jmitchell38488/todo/app/ui/view/holder/TodoItemEditHolder.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.text.method.ScrollingMovementMethod;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
@@ -88,6 +89,8 @@ public class TodoItemEditHolder {
             timeSelector.setVisibility(View.GONE);
             soundSelector.setVisibility(View.GONE);
         }
+
+        descriptionView.setMovementMethod(new ScrollingMovementMethod());
 
         pinnedSwitch.setChecked(mItem.isPinned());
         pinnedSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {

--- a/app/src/main/res/layout/fragment_edit_item.xml
+++ b/app/src/main/res/layout/fragment_edit_item.xml
@@ -57,20 +57,15 @@
                 android:id="@+id/item_edit_description_icon"
                 style="@style/EditThemeContainer.TextContainer.Icon"/>
 
-            <ScrollView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_toRightOf="@+id/item_edit_description_icon">
+            <com.github.jmitchell38488.todo.app.ui.view.RobotoLightTextView
+                android:id="@+id/item_edit_description"
+                android:inputType="textMultiLine|textCapSentences|textAutoCorrect"
+                android:hint="@string/item_edit_description_label"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:layout_toRightOf="@+id/item_edit_description_icon"
+                style="@style/EditThemeContainer.Input.TextAreaView"/>
 
-                <com.github.jmitchell38488.todo.app.ui.view.RobotoLightTextView
-                    android:id="@+id/item_edit_description"
-                    android:inputType="textMultiLine|textCapSentences|textAutoCorrect"
-                    android:hint="@string/item_edit_description_label"
-                    android:focusable="false"
-                    android:focusableInTouchMode="false"
-                    style="@style/EditThemeContainer.Input.TextArea"/>
-
-                </ScrollView>
         </RelativeLayout>
 
         <RelativeLayout

--- a/app/src/main/res/layout/list_item_fragment_notifications.xml
+++ b/app/src/main/res/layout/list_item_fragment_notifications.xml
@@ -8,7 +8,6 @@
     style="@style/ListThemeListItemContainer">
 
     <FrameLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -24,7 +23,6 @@
     </FrameLayout>
 
     <FrameLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/values-xxhdpi/dimens.xml
+++ b/app/src/main/res/values-xxhdpi/dimens.xml
@@ -15,6 +15,7 @@
     <dimen name="AppTheme.ListTextView.Large.textSize">12.5dp</dimen>
     <dimen name="AppTheme.ListTextView.DragHandle.layout_width">40dp</dimen>
     <dimen name="AppTheme.ListTextView.Icon.List.paddingRight">5dp</dimen>
+    <!--
     <dimen name="EditThemeContainer.Label.textSize">14.5dp</dimen>
     <dimen name="EditThemeContainer.Label.Small.textSize">11dp</dimen>
     <dimen name="EditThemeContainer.Switch.textSize">12dp</dimen>
@@ -29,4 +30,5 @@
     <dimen name="EditThemeContainer.OptionsContainer.paddingRight">6dp</dimen>
     <dimen name="EditThemeContainer.OptionsContainer.paddingTop">10dp</dimen>
     <dimen name="EditThemeContainer.Input.Large.textSize">14dp</dimen>
+    -->
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -299,15 +299,13 @@
         <item name="android:layout_marginTop">25dp</item>
     </style>
 
-    <style name="EditThemeContainer.Input.TextArea" parent="EditThemeContainer.Input">
-        <item name="android:minLines">4</item>
-        <item name="android:maxLines">9</item>
+    <style name="EditThemeContainer.Input.TextAreaView" parent="EditThemeContainer.Input">
+        <item name="android:lines">9</item>
+        <item name="android:scrollbars">vertical</item>
     </style>
 
     <style name="EditThemeContainer.Input.TextArea.Activity" parent="EditThemeContainer.Input">
-        <item name="android:minLines">10</item>
-        <item name="android:lines">10</item>
-        <item name="android:maxLines">100</item>
+        <item name="android:lines">22</item>
         <item name="android:textSize">@dimen/EditThemeContainer.Input.textSizeLarge</item>
     </style>
 


### PR DESCRIPTION
See: https://github.com/jmitchell38488/android-todo-app/issues/5

Updated the description text edit view to handle dynamically changing the no. of lines currently visible depending on focus state & font size. If more lines than what was visible was being displayed, then the text would overflow the current view, but wasn't being correctly scrolled.