### PR TITLE
GH-2, GH-6: Edit screen: Click on text to change 'switch' states

### DIFF
--- a/app/src/main/java/com/github/jmitchell38488/todo/app/ui/view/holder/TodoItemEditHolder.java
+++ b/app/src/main/java/com/github/jmitchell38488/todo/app/ui/view/holder/TodoItemEditHolder.java
@@ -3,7 +3,6 @@ package com.github.jmitchell38488.todo.app.ui.view.holder;
 import android.app.DatePickerDialog;
 import android.app.TimePickerDialog;
 import android.content.Context;
-import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.text.method.ScrollingMovementMethod;
@@ -15,10 +14,8 @@ import android.widget.Switch;
 import android.widget.TextView;
 
 import com.github.jmitchell38488.todo.app.R;
-import com.github.jmitchell38488.todo.app.data.Parcelable;
 import com.github.jmitchell38488.todo.app.data.model.TodoItem;
 import com.github.jmitchell38488.todo.app.data.model.TodoReminder;
-import com.github.jmitchell38488.todo.app.ui.fragment.EditItemFragment;
 import com.github.jmitchell38488.todo.app.util.AlarmUtility;
 
 import java.text.SimpleDateFormat;
@@ -46,9 +43,6 @@ public class TodoItemEditHolder {
 
     @BindView(R.id.item_edit_title) public EditText titleView;
     @BindView(R.id.item_edit_description) public TextView descriptionView;
-    @BindView(R.id.item_edit_pinned) public Switch pinnedSwitch;
-    @BindView(R.id.item_edit_completed) public Switch completedSwitch;
-    @BindView(R.id.item_edit_locked) public Switch lockedSwitch;
 
     @BindView(R.id.edit_item_time_selector) RelativeLayout timeSelector;
     @BindView(R.id.edit_item_sound_selector) RelativeLayout soundSelector;
@@ -67,6 +61,19 @@ public class TodoItemEditHolder {
     @BindView(R.id.item_edit_sound_icon) public TextView soundIcon;
     @BindView(R.id.item_edit_sound_field) public TextView soundField;
     @BindView(R.id.item_edit_sound_delete) public TextView soundDelete;
+
+    @BindView(R.id.item_edit_pinned_icon) TextView pinnedIcon;
+    @BindView(R.id.item_edit_pinned_text) TextView pinnedField;
+    @BindView(R.id.item_edit_pinned) public Switch pinnedSwitch;
+
+    @BindView(R.id.item_edit_locked_icon) TextView lockedIcon;
+    @BindView(R.id.item_edit_locked_text) TextView lockedField;
+    @BindView(R.id.item_edit_locked) public Switch lockedSwitch;
+
+    @BindView(R.id.item_edit_completed_icon) TextView completedIcon;
+    @BindView(R.id.item_edit_completed_text) TextView completedField;
+    @BindView(R.id.item_edit_completed) public Switch completedSwitch;
+
 
     DatePickerDialog.OnDateSetListener dateCallback = (view, year, monthOfYear, dayOfMonth) -> {
         reminderDate.set(Calendar.YEAR, year);
@@ -120,11 +127,22 @@ public class TodoItemEditHolder {
 
         descriptionView.setMovementMethod(new ScrollingMovementMethod());
 
+        pinnedIcon.setOnClickListener(v -> pinnedSwitch.setChecked(!mItem.isPinned()));
+        pinnedField.setOnClickListener(v -> pinnedSwitch.setChecked(!mItem.isPinned()));
         pinnedSwitch.setChecked(mItem.isPinned());
         pinnedSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
             mItem.setPinned(isChecked);
         });
 
+        lockedIcon.setOnClickListener(v -> lockedSwitch.setChecked(!mItem.isLocked()));
+        lockedField.setOnClickListener(v -> lockedSwitch.setChecked(!mItem.isLocked()));
+        lockedSwitch.setChecked(mItem.isLocked());
+        lockedSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            mItem.setLocked(isChecked);
+        });
+
+        completedIcon.setOnClickListener(v -> completedSwitch.setChecked(!mItem.isCompleted()));
+        completedField.setOnClickListener(v -> completedSwitch.setChecked(!mItem.isCompleted()));
         completedSwitch.setChecked(mItem.isCompleted());
         completedSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
             mItem.setCompleted(isChecked);
@@ -135,11 +153,6 @@ public class TodoItemEditHolder {
                 lockedSelector.setVisibility(View.VISIBLE);
                 pinnedSelector.setVisibility(View.VISIBLE);
             }
-        });
-
-        lockedSwitch.setChecked(mItem.isLocked());
-        lockedSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            mItem.setLocked(isChecked);
         });
 
         if (!TextUtils.isEmpty(mItem.getTitle())) {

--- a/app/src/main/java/com/github/jmitchell38488/todo/app/ui/view/holder/TodoItemEditHolder.java
+++ b/app/src/main/java/com/github/jmitchell38488/todo/app/ui/view/holder/TodoItemEditHolder.java
@@ -41,7 +41,10 @@ public class TodoItemEditHolder {
     boolean hasTriggeredDateClick = false;
     boolean hasTriggeredTimeClick = false;
 
+    @BindView(R.id.item_edit_title_icon) TextView titleIcon;
     @BindView(R.id.item_edit_title) public EditText titleView;
+
+    @BindView(R.id.item_edit_description_icon) TextView descriptionIcon;
     @BindView(R.id.item_edit_description) public TextView descriptionView;
 
     @BindView(R.id.edit_item_time_selector) RelativeLayout timeSelector;
@@ -125,6 +128,12 @@ public class TodoItemEditHolder {
             soundSelector.setVisibility(View.GONE);
         }
 
+        titleIcon.setOnClickListener(v -> {
+            titleView.setEnabled(true);
+            titleView.requestFocus();
+        });
+
+        descriptionIcon.setOnClickListener(v -> descriptionView.performClick());
         descriptionView.setMovementMethod(new ScrollingMovementMethod());
 
         pinnedIcon.setOnClickListener(v -> pinnedSwitch.setChecked(!mItem.isPinned()));

--- a/app/src/main/res/layout/fragment_edit_item.xml
+++ b/app/src/main/res/layout/fragment_edit_item.xml
@@ -170,6 +170,7 @@
 
             <com.github.jmitchell38488.todo.app.ui.view.RobotoLightTextView
                 android:hint="@string/item_edit_pin_label"
+                android:id="@+id/item_edit_pinned_text"
                 android:layout_toRightOf="@+id/item_edit_pinned_icon"
                 style="@style/EditThemeContainer.Input"/>
 
@@ -202,6 +203,7 @@
 
             <com.github.jmitchell38488.todo.app.ui.view.RobotoLightTextView
                 android:hint="@string/item_edit_locked_label"
+                android:id="@+id/item_edit_locked_text"
                 android:layout_toRightOf="@+id/item_edit_locked_icon"
                 style="@style/EditThemeContainer.Input"/>
 
@@ -234,6 +236,7 @@
 
             <com.github.jmitchell38488.todo.app.ui.view.RobotoLightTextView
                 android:hint="@string/item_edit_completed_label"
+                android:id="@+id/item_edit_completed_text"
                 android:layout_toRightOf="@+id/item_edit_completed_icon"
                 style="@style/EditThemeContainer.Input"/>
 

--- a/app/src/main/res/layout/fragment_edit_item.xml
+++ b/app/src/main/res/layout/fragment_edit_item.xml
@@ -59,12 +59,9 @@
 
             <com.github.jmitchell38488.todo.app.ui.view.RobotoLightTextView
                 android:id="@+id/item_edit_description"
-                android:inputType="textMultiLine|textCapSentences|textAutoCorrect"
                 android:hint="@string/item_edit_description_label"
-                android:focusable="false"
-                android:focusableInTouchMode="false"
                 android:layout_toRightOf="@+id/item_edit_description_icon"
-                style="@style/EditThemeContainer.Input.TextAreaView"/>
+                style="@style/EditThemeContainer.Input.ReadOnly.TextAreaView"/>
 
         </RelativeLayout>
 
@@ -85,15 +82,15 @@
                 android:id="@+id/item_edit_date_field"
                 android:hint="@string/item_edit_reminder_label"
                 android:layout_toRightOf="@+id/item_edit_date_icon"
-                style="@style/EditThemeContainer.Input" />
+                style="@style/EditThemeContainer.Input.ReadOnly" />
 
             <com.github.jmitchell38488.todo.app.ui.view.FontAwesomeTextView
                 android:layout_height="wrap_content"
                 android:text="@string/icon_cancel"
                 android:id="@+id/item_edit_date_delete"
-                style="@style/EditThemeContainer.TextContainer.Icon"
                 android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true" />
+                android:layout_alignParentEnd="true"
+                style="@style/EditThemeContainer.TextContainer.Icon" />
         </RelativeLayout>
 
         <RelativeLayout
@@ -113,16 +110,17 @@
             <com.github.jmitchell38488.todo.app.ui.view.RobotoLightTextView
                 android:id="@+id/item_edit_time_field"
                 android:hint="@string/item_edit_reminder_time_hint"
+                android:clickable="true"
                 android:layout_toRightOf="@+id/item_edit_time_icon"
-                style="@style/EditThemeContainer.Input"/>
+                style="@style/EditThemeContainer.Input.ReadOnly"/>
 
             <com.github.jmitchell38488.todo.app.ui.view.FontAwesomeTextView
                 android:layout_height="wrap_content"
                 android:text="@string/icon_cancel"
-                android:id="@+id/item_edit_time_delete"
-                style="@style/EditThemeContainer.TextContainer.Icon"
                 android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true" />
+                android:layout_alignParentEnd="true"
+                android:id="@+id/item_edit_time_delete"
+                style="@style/EditThemeContainer.TextContainer.Icon" />
         </RelativeLayout>
 
         <RelativeLayout
@@ -143,15 +141,15 @@
                 android:id="@+id/item_edit_sound_field"
                 android:hint="@string/item_edit_reminder_alarm_hint"
                 android:layout_toRightOf="@+id/item_edit_sound_icon"
-                style="@style/EditThemeContainer.Input"/>
+                style="@style/EditThemeContainer.Input.ReadOnly"/>
 
             <com.github.jmitchell38488.todo.app.ui.view.FontAwesomeTextView
                 android:layout_height="wrap_content"
                 android:text="@string/icon_cancel"
                 android:id="@+id/item_edit_sound_delete"
-                style="@style/EditThemeContainer.TextContainer.Icon"
                 android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true" />
+                android:layout_alignParentEnd="true"
+                style="@style/EditThemeContainer.TextContainer.Icon"/>
         </RelativeLayout>
 
         <RelativeLayout
@@ -172,14 +170,14 @@
                 android:hint="@string/item_edit_pin_label"
                 android:id="@+id/item_edit_pinned_text"
                 android:layout_toRightOf="@+id/item_edit_pinned_icon"
-                style="@style/EditThemeContainer.Input"/>
+                style="@style/EditThemeContainer.Input.ReadOnly"/>
 
             <LinearLayout
                 android:layout_width="@dimen/EditThemeContainer.Switch.layout_width"
                 android:layout_height="wrap_content"
                 android:gravity="end"
                 android:layout_alignParentRight="true"
-                android:layout_alignParentEnd="true" >
+                android:layout_alignParentEnd="true">
                 <Switch
                     android:id="@+id/item_edit_pinned"
                     style="@style/EditThemeContainer.Switch"/>
@@ -205,7 +203,7 @@
                 android:hint="@string/item_edit_locked_label"
                 android:id="@+id/item_edit_locked_text"
                 android:layout_toRightOf="@+id/item_edit_locked_icon"
-                style="@style/EditThemeContainer.Input"/>
+                style="@style/EditThemeContainer.Input.ReadOnly"/>
 
             <LinearLayout
                 android:layout_width="@dimen/EditThemeContainer.Switch.layout_width"
@@ -238,7 +236,7 @@
                 android:hint="@string/item_edit_completed_label"
                 android:id="@+id/item_edit_completed_text"
                 android:layout_toRightOf="@+id/item_edit_completed_icon"
-                style="@style/EditThemeContainer.Input"/>
+                style="@style/EditThemeContainer.Input.ReadOnly"/>
 
             <LinearLayout
                 android:layout_width="@dimen/EditThemeContainer.Switch.layout_width"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -199,6 +199,9 @@
         <item name="android:layout_gravity">center_horizontal|top</item>
         <item name="android:gravity">center_horizontal|top</item>
         <item name="android:layout_marginTop">@dimen/EditThemeContainer.TextContainer.Icon.layout_marginTop</item>
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">false</item>
+        <item name="android:focusableInTouchMode">false</item>
     </style>
 
     <style name="EditThemeContainer.TextContainer.Row" parent="EditThemeContainer.TextContainer">
@@ -270,11 +273,21 @@
         <item name="android:focusableInTouchMode">true</item>
     </style>
 
+    <style name="EditThemeContainer.Input.ReadOnly" parent="EditThemeContainer.Input">
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">false</item>
+        <item name="android:focusableInTouchMode">false</item>
+    </style>
+
     <style name="EditThemeContainer.Input.Selector" parent="EditThemeContainer.Input">
         <item name="android:paddingBottom">@dimen/EditThemeContainer.Input.Selector.paddingBottom</item>
     </style>
 
     <style name="EditThemeContainer.Input.Large" parent="EditThemeContainer.Input">
+        <item name="android:textSize">@dimen/EditThemeContainer.Input.Large.textSize</item>
+    </style>
+
+    <style name="EditThemeContainer.Input.ReadOnly.Large" parent="EditThemeContainer.Input.ReadOnly">
         <item name="android:textSize">@dimen/EditThemeContainer.Input.Large.textSize</item>
     </style>
 
@@ -299,7 +312,7 @@
         <item name="android:layout_marginTop">25dp</item>
     </style>
 
-    <style name="EditThemeContainer.Input.TextAreaView" parent="EditThemeContainer.Input">
+    <style name="EditThemeContainer.Input.ReadOnly.TextAreaView" parent="EditThemeContainer.Input.ReadOnly">
         <item name="android:lines">9</item>
         <item name="android:scrollbars">vertical</item>
     </style>


### PR DESCRIPTION
See: https://github.com/jmitchell38488/android-todo-app/issues/2
See: https://github.com/jmitchell38488/android-todo-app/issues/6

Updated the edit view to make most items clickable instead of focusable. The only field that should hold focus is the title edit. The switches can now have their state changed from the icons & titles, but there's still focus issues when you click on the switch, or when you click into the title edit, since focus isn't lost and the touch events don't bubble correctly.