### PR TITLE
[0.6] Edit View: Add clickable links to the description box

### DIFF
--- a/app/src/main/res/layout/fragment_edit_description.xml
+++ b/app/src/main/res/layout/fragment_edit_description.xml
@@ -16,6 +16,7 @@
             android:id="@+id/item_edit_description"
             android:inputType="textMultiLine|textCapSentences|textAutoCorrect"
             android:hint="@string/item_edit_description_label"
+            android:linksClickable="true"
             style="@style/EditThemeContainer.Input.TextArea.Activity"/>
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_edit_item.xml
+++ b/app/src/main/res/layout/fragment_edit_item.xml
@@ -60,6 +60,8 @@
             <com.github.jmitchell38488.todo.app.ui.view.RobotoLightTextView
                 android:id="@+id/item_edit_description"
                 android:hint="@string/item_edit_description_label"
+                android:linksClickable="true"
+                android:autoLink="all"
                 android:layout_toRightOf="@+id/item_edit_description_icon"
                 style="@style/EditThemeContainer.Input.ReadOnly.TextAreaView"/>
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
         classpath 'me.tatarka:gradle-retrolambda:3.3.1'
     }


### PR DESCRIPTION
Issue: https://github.com/jmitchell38488/android-todo-app/issues/35

Updated the layout templates to allow links to be clickable. Android automatically handles link generation within the text.